### PR TITLE
refactor: cleaner $.expr + match order with spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ generate:
 
 test: generate
 	${ts} test
+
+fmt:
+	npx prettier --tab-width 4 -w grammar.js


### PR DESCRIPTION
First of all, great job on this tree-sitter parser. This is the first time I'm working with tree-sitter, so please be kind.

I'm debugging a few issues but had a hard time navigating the code so I spent a bit of time refactoring first.

This PR does 3 things:

- Format the JS with `prettier`
- Split out the `$.expr` into separate items (and matched order with the Jsonnet spec, there were a few differences)
- Matched order of other items with the Jsonnet spec

I've maintained the visibility by using the underscore prefix on all new items but we might want to make them visible in the output (and perhaps hide `$.expr` as it's ubiquitous) in a follow up PR.