### PR TITLE
fix: compare with 'in' operator

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -156,7 +156,7 @@ module.exports = grammar({
                 [PREC.multiplicative, choice("*", "/", "%")],
                 [PREC.additive, choice("+", "-")],
                 [PREC.bitshift, choice("<<", ">>")],
-                [PREC.comparison, choice("<", "<=", ">", ">=")],
+                [PREC.comparison, choice("<", "<=", ">", ">=", "in")],
                 [PREC.equality, choice("==", "!=")],
                 [PREC.bitand, "&"],
                 [PREC.bitxor, "^"],
@@ -210,7 +210,7 @@ module.exports = grammar({
         // error expr
         expr_error: ($) => prec.right(seq("error", $.expr)),
 
-        _expr_super: ($) => seq($.expr, "in", $.super),
+        _expr_super: ($) => prec(PREC.comparison, seq($.expr, "in", $.super)),
 
         _parenthesis: ($) => seq("(", $.expr, ")"),
 

--- a/grammar.js
+++ b/grammar.js
@@ -218,18 +218,17 @@ module.exports = grammar({
             choice(
                 // seq($.member, repeat(seq(",", $.member)), optional(",")),
                 commaSep1($.member, true),
-                seq(
-                    repeat(seq($.objlocal, ",")),
-                    "[",
-                    $.expr,
-                    "]",
-                    ":",
-                    $.expr,
-                    repeat(seq(",", $.objlocal)),
-                    optional(","),
-                    $.forspec,
-                    optional($.compspec),
-                ),
+                $._objforloop,
+            ),
+
+        _objforloop: ($) =>
+            seq(
+                repeat(seq($.objlocal, ",")),
+                $.field,
+                repeat(seq(",", $.objlocal)),
+                optional(","),
+                $.forspec,
+                optional($.compspec),
             ),
 
         member: ($) =>

--- a/test/corpus/fieldname.txt
+++ b/test/corpus/fieldname.txt
@@ -74,14 +74,14 @@ Resolve expr in fieldname key 3
 ===============================
 
 local Margarita(salted) = {
-      ingredients: [
-          { kind: 'Tequila Blanco', qty: 2 },
-            ],
-              [if salted then 'garnish']: 'Salt',
+  [if salted then 'garnish']: 'Salt',
+  ingredients: [
+    { kind: 'Tequila Blanco', qty: 2 },
+  ],
 };
 {
-      Margarita: Margarita(true),
-        'Margarita Unsalted': Margarita(false),
+  Margarita: Margarita(true),
+  'Margarita Unsalted': Margarita(false),
 }
 
 ---
@@ -97,6 +97,22 @@ local Margarita(salted) = {
      (param
       identifier: (id)))
     body: (expr
+    (member
+      (field
+       (fieldname
+        (expr
+         condition: (expr (id))
+         consequence:
+         (expr
+          (string
+           (string_start)
+           (string_content)
+           (string_end)))))
+       (expr
+        (string
+         (string_start)
+         (string_content)
+         (string_end)))))
      (member
       (field
        (fieldname (id))
@@ -116,22 +132,7 @@ local Margarita(salted) = {
             (id))
            (expr
             (number))))))))
-     (member
-      (field
-       (fieldname
-        (expr
-         condition: (expr (id))
-         consequence:
-         (expr
-          (string
-           (string_start)
-           (string_content)
-           (string_end)))))
-       (expr
-        (string
-         (string_start)
-         (string_content)
-         (string_end)))))))
+     ))
    (expr
     (member
      (field

--- a/test/corpus/fieldname.txt
+++ b/test/corpus/fieldname.txt
@@ -1,6 +1,6 @@
-=============================
-Resolve expr in fieldname key
-=============================
+===============================
+Resolve expr in fieldname key 1
+===============================
 
 local a = 'a';
 { [a]: 'a' }
@@ -29,3 +29,126 @@ local a = 'a';
                 (string_start)
                 (string_content)
                 (string_end)))))))))
+
+===============================
+Resolve expr in fieldname key 2
+===============================
+
+local prefix = 'Happy Hour ';
+{
+  [prefix + 'Mimosa']: 'Champagne',
+}
+
+---
+
+(document
+  (expr
+    (local_bind
+      (local)
+      (bind
+        (id)
+        (expr
+          (string
+            (string_start)
+            (string_content)
+            (string_end))))
+      (expr
+        (member
+          (field
+            (fieldname
+              (expr
+                (expr (id))
+                (expr
+                  (string
+                    (string_start)
+                    (string_content)
+                    (string_end)))))
+            (expr
+              (string
+                (string_start)
+                (string_content)
+                (string_end)))))))))
+
+===============================
+Resolve expr in fieldname key 3
+===============================
+
+local Margarita(salted) = {
+      ingredients: [
+          { kind: 'Tequila Blanco', qty: 2 },
+            ],
+              [if salted then 'garnish']: 'Salt',
+};
+{
+      Margarita: Margarita(true),
+        'Margarita Unsalted': Margarita(false),
+}
+
+---
+
+(document
+ (expr
+  (local_bind
+   (local)
+   (bind
+    function: (id)
+    params:
+    (params
+     (param
+      identifier: (id)))
+    body: (expr
+     (member
+      (field
+       (fieldname (id))
+       (expr
+        (expr
+         (member
+          (field
+           (fieldname (id))
+           (expr
+            (string
+             (string_start)
+             (string_content)
+             (string_end)))))
+         (member
+          (field
+           (fieldname
+            (id))
+           (expr
+            (number))))))))
+     (member
+      (field
+       (fieldname
+        (expr
+         condition: (expr (id))
+         consequence:
+         (expr
+          (string
+           (string_start)
+           (string_content)
+           (string_end)))))
+       (expr
+        (string
+         (string_start)
+         (string_content)
+         (string_end)))))))
+   (expr
+    (member
+     (field
+      (fieldname (id))
+      (expr
+       (expr (id))
+       (args
+        (expr (true))))))
+    (member
+     (field
+      (fieldname
+       (string
+        (string_start)
+        (string_content)
+        (string_end)))
+      (expr
+       (expr (id))
+       (args
+        (expr
+         (false))))))))))

--- a/test/corpus/fieldname.txt
+++ b/test/corpus/fieldname.txt
@@ -1,0 +1,31 @@
+=============================
+Resolve expr in fieldname key
+=============================
+
+local a = 'a';
+{ [a]: 'a' }
+
+---
+
+(document
+  (expr
+    (local_bind
+      (local)
+      (bind
+        (id)
+        (expr
+          (string
+            (string_start)
+            (string_content)
+            (string_end))))
+      (expr
+        (member
+          (field
+            (fieldname
+              (expr
+                (id)))
+            (expr
+              (string
+                (string_start)
+                (string_content)
+                (string_end)))))))))

--- a/test/corpus/forloop.txt
+++ b/test/corpus/forloop.txt
@@ -1,0 +1,44 @@
+======================
+For loop in array
+======================
+
+[
+  i
+  for i in std.range(0,10)
+]
+
+---
+
+(document
+  (expr
+    (expr (id))
+    (forspec
+      (id)
+      (expr (expr (expr (id)) (id))
+      (args (expr (number)) (expr (number)))))))
+
+======================
+For loop in object
+======================
+
+{
+  ['item' + i]: i
+  for i in std.range(0,10)
+}
+
+---
+
+(document
+  (expr
+    (expr
+      (expr
+          (string
+            (string_start)
+            (string_content)
+            (string_end)))
+      (expr (id)))
+      (expr (id))
+      (forspec
+        (id)
+        (expr (expr (expr (id)) (id))
+        (args (expr (number)) (expr (number)))))))

--- a/test/corpus/forloop.txt
+++ b/test/corpus/forloop.txt
@@ -30,14 +30,48 @@ For loop in object
 
 (document
   (expr
-    (expr
-      (expr
-          (string
-            (string_start)
-            (string_content)
-            (string_end)))
+    (field
+      (fieldname
+        (expr
+          (expr
+              (string
+                (string_start)
+                (string_content)
+                (string_end)))
+          (expr (id))))
       (expr (id)))
-      (expr (id))
+      (forspec
+        (id)
+        (expr (expr (expr (id)) (id))
+        (args (expr (number)) (expr (number)))))))
+
+================================
+For loop in object with function
+================================
+
+{
+  ['item' + i](v): i + v
+  for i in std.range(0,10)
+}
+
+---
+
+(document
+  (expr
+    (field
+      (fieldname
+        (expr
+          (expr
+              (string
+                (string_start)
+                (string_content)
+                (string_end)))
+          (expr (id))))
+      (params
+        (param (id)))
+      (expr
+        (expr (id))
+        (expr (id))))
       (forspec
         (id)
         (expr (expr (expr (id)) (id))

--- a/test/corpus/inoperator.txt
+++ b/test/corpus/inoperator.txt
@@ -1,0 +1,68 @@
+======================
+In operator on object
+======================
+
+local obj = { a: null };
+'a' in obj
+
+---
+
+(document
+  (expr
+    (local_bind
+      (local)
+      (bind
+        (id)
+        (expr
+          (member
+            (field
+              (fieldname
+                (id))
+              (expr
+                (null))))))
+      (expr
+        (expr
+          (string
+            (string_start)
+            (string_content)
+            (string_end)))
+        (expr
+          (id))))))
+
+======================
+In operator on super
+======================
+
+local obj = { a: null };
+obj + { b: 'a' in super }
+
+---
+
+(document
+  (expr
+    (local_bind
+      (local)
+      (bind
+        (id)
+        (expr
+          (member
+            (field
+              (fieldname
+                (id))
+              (expr
+                (null))))))
+      (expr
+        (expr
+          (id))
+        (expr
+          (member
+            (field
+              (fieldname
+                (id))
+              (expr
+                (expr
+                  (string
+                    (string_start)
+                    (string_content)
+                    (string_end)))
+                (super)))))))))


### PR DESCRIPTION
Binary op "in" comparison `'string' in obj` wasn't working properly, this PR adds it to the grammar.

This PR also adds test for comparison and for loops as they both deal with the 'in' keyword.

Also fixes #13 (see comments)