### PR TITLE
fix: resolve expr in key name

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -203,7 +203,10 @@ module.exports = grammar({
         ifspec: ($) => seq("if", $.expr),
 
         fieldname: ($) =>
-            prec.right(choice($.id, $.string, seq("[", $.expr, "]"))),
+            prec.right(
+                PREC.application_indexing,
+                choice($.id, $.string, seq("[", $.expr, "]")),
+            ),
 
         bind: ($) =>
             choice(

--- a/test/corpus/fieldname.txt
+++ b/test/corpus/fieldname.txt
@@ -1,0 +1,31 @@
+=============================
+Resolve expr in fieldname key
+=============================
+
+local a = 'a';
+{ [a]: 'a' }
+
+---
+
+(document
+  (expr
+    (local_bind
+      (local)
+      (bind
+        (id)
+        (expr
+          (string
+            (string_start)
+            (string_content)
+            (string_end))))
+      (expr
+        (member
+          (field
+            (fieldname
+              (expr
+                (id)))
+            (expr
+              (string
+                (string_start)
+                (string_content)
+                (string_end)))))))))


### PR DESCRIPTION
When there is an expression in fieldname, it doesn't always resolve correctly. This PR
adds precedence to ensure it resolves.

This PR also adds a test case for this.