### PR TITLE
fix: parse multiline string

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -361,15 +361,15 @@ module.exports = grammar({
                 ),
                 // ||| Quotes
                 seq(
-                    optional("@"),
-                    alias($._string_start, $.string_start),
-                    alias($._string_content, $.string_content),
-                    alias($._string_end, $.string_end),
+                    alias($._multiline, $.string_start),
+                    alias($._str_multiline, $.string_content),
+                    alias($._multiline, $.string_end),
                 ),
             ),
 
         _single: () => "'",
         _double: () => '"',
+        _multiline: () => "|||",
 
         _str_double: ($) =>
             repeat1(
@@ -389,6 +389,22 @@ module.exports = grammar({
 
         escape_sequence: () =>
             token.immediate(seq("\\", /(\"|\\|\/|b|f|n|r|t|u)/)),
+
+        _str_multiline: ($) =>
+            repeat1(
+                token.immediate(
+                    prec(
+                        1,
+                        repeat1(
+                            choice(
+                                /[^\|]/, // Catch any character until | is found
+                                /\|[^\|]/, // Allow single |
+                                /\|\|[^\|]/, // Allow double ||
+                            ),
+                        ),
+                    ),
+                ),
+            ),
     },
 });
 

--- a/test/corpus/string.txt
+++ b/test/corpus/string.txt
@@ -1,0 +1,85 @@
+==============
+Double quotes
+==============
+
+"abc"
+
+---
+
+(document
+  (expr
+  (string
+    (string_start)
+    (string_content)
+    (string_end))))
+
+==============
+Single quotes
+==============
+
+'abc'
+
+---
+
+(document
+  (expr
+  (string
+    (string_start)
+    (string_content)
+    (string_end))))
+
+==============
+Multiple lines - single line
+==============
+
+|||
+  abc
+|||
+
+---
+
+(document
+  (expr
+  (string
+    (string_start)
+    (string_content)
+    (string_end))))
+
+==============
+Multiple lines
+==============
+
+|||
+  abc
+  dd
+  abc
+|||
+
+---
+
+(document
+  (expr
+  (string
+    (string_start)
+    (string_content)
+    (string_end))))
+
+==============
+Multiple lines with one or two | in line
+==============
+
+|||
+  abc
+  aa|aa
+  aa||aa
+  abc
+|||
+
+---
+
+(document
+  (expr
+  (string
+    (string_start)
+    (string_content)
+    (string_end))))


### PR DESCRIPTION
Parsing multiline string with optionally one or two pipe `|` symbols in it.

According to spec the parser should also allow triple pipe in the string_content but I couldn't get that to work reliably.

Spec:

> Text block, beginning with |||, followed by optional whitespace and a new-line. The next non-empty line must be prefixed with some non-zero length whitespace W. The block ends at the first subsequent line that is non-empty and does not begin with W, and it is an error if this line does not contain some optional whitespace followed by |||. The content of the string is the concatenation of all the lines between the two |||, which either begin with W (in which case that prefix is stripped) or they are empty lines (in which case they remain as empty lines). The line ending style in the file is preserved in the string. This form cannot be used in import statements.

> The next non-empty line must be prefixed with some non-zero length whitespace W.

Or with other words, the text is indented after the first `|||`. I found some [evidence](https://github.com/tree-sitter/tree-sitter/discussions/1215) that tree-sitter can parse indentation, but couldn't get to work either.

Some additional corpus tests for the triple pipe:

```

==============
Multiple lines with ||| as a line
==============

|||
  abc
  |||
  abc
|||

---

(document
  (string
    (string_start)
    (string_content)
    (string_end)))

==============
Multiple lines with ||| in middle of line
==============

|||
  abc
  aa|aa
  aa||aa
  aa|||aa
  abc
|||

---

(document
  (string
    (string_start)
    (string_content)
    (string_end)))

==============
Multiple lines with ||| at line beginning
==============

|||
  abc
  |||aa
  abc
|||

---

(document
  (string
    (string_start)
    (string_content)
    (string_end)))

==============
Multiple lines with ||| at line end
==============

|||
  abc
  aaa|||
  abc
|||

---

(document
  (string
    (string_start)
    (string_content)
    (string_end)))

==============
Multiple lines - assigned
==============

{

  a: |||
    abc
  |||
  ,
}

---

(document
  (object
    (member
      (field
        (fieldname
          (id))
        (string
          (string_start)
          (string_content)
          (string_end))))))
```