### PR TITLE
chore: split queries

### DIFF
--- a/queries/extends.scm
+++ b/queries/extends.scm
@@ -1,0 +1,47 @@
+;;;; Extends the Jsonnet highlighting
+;; inherits: jsonnet
+;; extends
+
+;;; References - depends on locals.scm
+
+; Make reference same color as parameter 
+; (may incur performance issues on big files)
+; Depends on locals.scm
+((id) @parameter.reference
+ (#is? @parameter.reference parameter))
+
+((id) @function.reference
+ (#is? @function.reference function))
+
+((id) @variable.reference
+ (#is? @variable.reference var))
+
+((id) @variable.local
+ (#is? @variable.reference var))
+
+; References do not apply to static field IDs
+; Workaround for `(#is-not? local)` not being supported
+(fieldname (id) @field)
+(fieldname (string (string_content) @field))
+
+; But it does apply if ID in an expression
+(fieldname
+ ("["
+  (id) @parameter.reference
+  "]"
+  (#is? @parameter.reference parameter)))
+(fieldname
+ ("["
+  (id) @variable.local
+  "]"
+  (#is? @variable.reference var)))
+
+;;; Linting
+
+; Emphasize implicit plus usage
+(implicit_plus
+  (_ "}"? @text.danger)
+  (object
+    "{" @text.danger
+  )
+)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -14,18 +14,23 @@
 "for" @repeat
 "in" @keyword.operator
 "function" @keyword.function
+
 [
   "if"
   "then"
   "else"
 ] @conditional
+
 [
   (local)
   (tailstrict)
   "function"
+] @keyword
+
+[
   "assert"
   "error"
-] @keyword
+] @exception
 
 [
   (dollar)
@@ -81,84 +86,36 @@
   (importstr)
 ] @include
 
-; References
+; Fields
 
-; Make reference same color as parameter 
-; (may incur performance issues on big files)
-; Depends on locals.scm
-((id) @parameter.reference
- (#is? @parameter.reference parameter))
-
-((id) @function.reference
- (#is? @function.reference function))
-
-((id) @var.reference
- (#is? @var.reference var))
-((id) @define
- (#is? @var.reference var))
-
-; References do not apply to static field IDs
-; Workaround for `(#is-not? local)` not supported
 (fieldname (id) @field)
-(fieldname (string
-             (string_start) @text.strong
-             (string_content) @field
-             (string_end) @text.strong
-           ))
-
-; But it does apply if ID in an expression
-(fieldname
- ("["
-  (id) @parameter.reference
-  "]"
-  (#is? @parameter.reference parameter)))
-(fieldname
- ("["
-  (id) @define
-  "]"
-  (#is? @var.reference var)))
+(fieldname (string (string_content) @field))
 
 ; Functions
 (field
   function: (fieldname (id) @function))
 (field
   function: (fieldname
-              (string
-                (string_start) @text.strong
-                (string_content) @function
-                (string_end) @text.strong
-              )))
+              (string (string_content) @function)))
 (param
   identifier: (id) @parameter)
 
-(bind (id) @define)
+(bind (id) @variable.local)
 (bind function: (id) @function)
 
 ; Function call
 (functioncall
   (fieldaccess
-    last: (id) @function.call
-  )?
+    last: (id) @function.call)?
   (fieldaccess_super
-    (id) @function.call
-  )?
+    (id) @function.call)?
   (id)? @function.call
   "("
   (args
     (named_argument
       (id) @parameter
-    )
-  )?
-  ")"
-)
-
-; Emphasize implicit plus usage
-(implicit_plus
-  (_ "}"? @text.danger)
-  (object
-    "{" @text.danger
-  )
-)
+    ))?
+  ")")
 
 ; ERROR
 (ERROR) @error


### PR DESCRIPTION
While downstreaming the queries into nvim-treesitter, I got a thorough
review from the maintainers there, this split the highlights into two
parts:

highlights.scm:

- sane default highlights that work well
- included in nvim-treesitter

extends.scm:

- additional highlights for references and linting
- references are a bit more experimental and might be slow on big files
- the linting is opinionated
- included in nvim-jsonnet