### PR TITLE
more lenient tree-sitter dep range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-jsonnet"
 description = "jsonnet grammar for the tree-sitter parsing library"
-version = "0.0.1"
+version = "0.0.2"
 keywords = ["incremental", "parsing", "jsonnet"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-jsonnet"
@@ -9,18 +9,13 @@ edition = "2018"
 license = "MIT"
 
 build = "bindings/rust/build.rs"
-include = [
-  "bindings/rust/*",
-  "grammar.js",
-  "queries/*",
-  "src/*",
-]
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 
 [lib]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.22.6"
+tree-sitter = "^0.24.5"
 
 [build-dependencies]
-cc = "1.0"
+cc = ">=1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-jsonnet",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "jsonnet grammar for tree-sitter",
   "main": "bindings/node",
   "types": "bindings/node",
@@ -21,7 +21,7 @@
     "node-gyp-build": "^4.8.0"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.0"
+    "tree-sitter": "^0.22.4"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {
@@ -29,7 +29,7 @@
     }
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.22.6",
+    "tree-sitter-cli": "^0.24.6",
     "prebuildify": "^6.0.0"
   },
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-jsonnet"
 description = "Jsonnet grammar for tree-sitter"
-version = "0.0.1"
+version = "0.0.2"
 keywords = ["incremental", "parsing", "tree-sitter", "jsonnet"]
 classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Topic :: Software Development :: Compilers",
   "Topic :: Text Processing :: Linguistic",
-  "Typing :: Typed"
+  "Typing :: Typed",
 ]
 requires-python = ">=3.8"
 license.text = "MIT"
@@ -22,7 +22,7 @@ readme = "README.md"
 Homepage = "https://github.com/tree-sitter/tree-sitter-jsonnet"
 
 [project.optional-dependencies]
-core = ["tree-sitter~=0.21"]
+core = ["tree-sitter~=0.23"]
 
 [tool.cibuildwheel]
 build = "cp38-*"


### PR DESCRIPTION
This makes it possible to depend on `tree-sitter-jsonnet` from packages using newer versions of `tree-sitter`.