### PR TITLE
fix(scanner.c): allow trimmed multiline string syntax

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -72,6 +72,7 @@ void tree_sitter_jsonnet_external_scanner_deserialize(void *payload, const char 
 
 static bool scan_block_start(TSLexer *lexer) {
   if (consume_char('|', lexer) && consume_char('|', lexer) && consume_char('|', lexer)) {
+    consume_char('-', lexer); // (optional)
     return true;
   }
 


### PR DESCRIPTION
added by https://github.com/google/jsonnet/pull/1175, released in jsonnet v0.21.0